### PR TITLE
Handle job error

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -25,11 +25,15 @@ def run_classification(job_pk, input_filetype):
     results_fp = run_dir / 'results.tsv'
     # Get command and execute
     command = get_classification_command(results_fp, data_dir)
-    execute_command(command)
-    execute_command(f'rm -r {data_dir}')
-    # Update record
-    job.status = 'completed'
-    job.save()
+    try:
+        execute_command(command)
+        job.status = 'completed'
+    except ValueError:
+        job.status = 'failed'
+    finally:
+        execute_command(f'rm -r {data_dir}')
+        # Update record
+        job.save()
 
 
 def get_classification_command(results_fp, data_dir):
@@ -77,5 +81,5 @@ def execute_command(command):
         print('Failed to run command:', result.args, file=sys.stderr)
         print('stdout:', result.stdout, file=sys.stderr)
         print('stderr:', result.stderr, file=sys.stderr)
-        sys.exit(1)
+        raise ValueError
     return result

--- a/frontend/src/ResultsPage.js
+++ b/frontend/src/ResultsPage.js
@@ -34,7 +34,9 @@ class ResultsPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-		if (this.props.location !== prevProps.location) {
+    if (this.state.job_data.status == "completed" || this.state.job_data.status == "failed")
+        clearInterval(this.timer);
+    if (this.props.location !== prevProps.location) {
       this.prepareResults();
     }
   }

--- a/frontend/src/ResultsPage.js
+++ b/frontend/src/ResultsPage.js
@@ -209,8 +209,8 @@ class ResultsPage extends React.Component {
               <>
                 <Segment placeholder>
                   <Header icon>
-                    {renderJobIcon(this.state.job_data.status)}
-                    Job is {this.state.job_data.status}
+                    {renderJobStatusIcon(this.state.job_data.status)}
+                    {renderJobStatusText(this.state.job_data.status)}
                   </Header>
                 </Segment>
               </>
@@ -222,7 +222,7 @@ class ResultsPage extends React.Component {
 
 
 // TODO: reused from ResultsPage.js, cleanup
-function renderJobIcon(job_status) {
+function renderJobStatusIcon(job_status) {
   switch(job_status) {
     case 'initialising':
       return <Icon loading name='circle notch' />;
@@ -236,6 +236,15 @@ function renderJobIcon(job_status) {
       return <Icon name='exclamation circle' color='red' />;
     default:
       return <Icon name='question circle outline' />;
+  }
+}
+
+
+function renderJobStatusText(job_status) {
+  if (job_status === 'failed') {
+    return 'Job failed'
+  } else {
+    return `Job is ${job_status}`
   }
 }
 


### PR DESCRIPTION
Issue: 
 * When a job fails as in https://github.com/scwatts/spectracl/issues/7 the job is never marked as `completed` nor `failed`.

Changes:
 * save the failed status in the db
 * inform the user that the job failed
 * stop pulling job status as it will not changed when `completed` or `failed`